### PR TITLE
Stop the term at the first "is|are"

### DIFF
--- a/lib/lita/handlers/remember.rb
+++ b/lib/lita/handlers/remember.rb
@@ -11,7 +11,7 @@ module Lita
       )
 
       route(
-        /^[Rr]emember\s(?<term>.+)\s(is|are)\s(?<definition>.+)$/,
+        /^[Rr]emember\s(?<term>.+?)\s(is|are)\s(?<definition>.+)$/,
         :remember,
         command: true,
         help: {

--- a/spec/lita/handlers/remember_spec.rb
+++ b/spec/lita/handlers/remember_spec.rb
@@ -84,6 +84,12 @@ describe Lita::Handlers::Remember, lita_handler: true do
       send_command("search terms for foo")
       expect(replies.last).to eq("No matching terms found.")
     end
+
+    it "stops term names at the first 'is'" do
+      send_command "remember it is what it is"
+      send_command "what is it"
+      expect(replies.last).to start_with("it is what it is")
+    end
   end
 
 end


### PR DESCRIPTION
Things like "remember the question is what is 6_9" results in a term
of "the question is what" and a definition of "6_9", which is highly
unlikely to be what was desired.  (Variations of this were tried by 3
users in less than 24 hours.)
